### PR TITLE
Add grammar to context

### DIFF
--- a/src/csg_enumerator.jl
+++ b/src/csg_enumerator.jl
@@ -9,7 +9,7 @@ function propagate_constraints(
     domain = child_rules
 
     for propagator ∈ grammar.constraints
-        domain = propagate(propagator, context, domain)
+        domain = propagate(propagator, grammar, context, domain)
     end
 
     return domain
@@ -37,7 +37,7 @@ function Base.iterate(iter::ContextSensitiveEnumerator)
     if isterminal(grammar, node)
         return (deepcopy(node), node)
     else
-        context = GrammarContext(node, grammar)
+        context = GrammarContext(node)
         node, worked = _next_state!(node, grammar, max_depth, context)
         while !worked
             # increment root's rule
@@ -61,13 +61,13 @@ end
 
 function Base.iterate(iter::ContextSensitiveEnumerator, state::RuleNode)
     grammar, max_depth = iter.grammar, iter.max_depth
-    context = GrammarContext(state, grammar)
+    context = GrammarContext(state)
     node, worked = _next_state!(state, grammar, max_depth, context)
     
     while !worked
         # increment root's rule
         init_node = RuleNode(0)  # needed for propagating constraints on the root node 
-        init_context = GrammarContext(init_node, grammar)
+        init_context = GrammarContext(init_node)
 
         rules = [x for x ∈ grammar[iter.sym]]
         rules = propagate_constraints(grammar, init_context, rules)
@@ -76,7 +76,7 @@ function Base.iterate(iter::ContextSensitiveEnumerator, state::RuleNode)
         if i < length(rules)
             node, worked = RuleNode(rules[i+1]), true
             if !isterminal(grammar, node)
-                context = GrammarContext(node, grammar)
+                context = GrammarContext(node)
                 node, worked = _next_state!(node, grammar, max_depth, context)
             end
         else
@@ -115,7 +115,7 @@ function _next_state!(node::RuleNode, grammar::ContextSensitiveGrammar, max_dept
                 i = 0
                 child = RuleNode(0)
 
-                new_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation), grammar)
+                new_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation))
                 push!(new_context.nodeLocation, child_index)
 
                 child_rules = [x for x in grammar[c]]  # select all applicable rules
@@ -150,7 +150,7 @@ function _next_state!(node::RuleNode, grammar::ContextSensitiveGrammar, max_dept
                 child_index -= 1
                 child = node.children[child_index]
         
-                new_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation), grammar)
+                new_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation))
                 push!(new_context.nodeLocation, child_index)
 
                 child, child_worked = _next_state!(child, grammar, max_depth-1, new_context)
@@ -190,7 +190,7 @@ function _next_state!(node::RuleNode, grammar::ContextSensitiveGrammar, max_dept
                         i = 0
                         child = RuleNode(0)
 
-                        new_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation), grammar)
+                        new_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation))
                         push!(new_context.nodeLocation, child_index2)
 
                         child_rules = [x for x in grammar[c]]  # take all applicable rules

--- a/src/csg_priority_enumerator.jl
+++ b/src/csg_priority_enumerator.jl
@@ -116,7 +116,7 @@ function _expand(node::RuleNode, grammar::ContextSensitiveGrammar, max_depth::In
         child_type = childtypes[length(node.children) + 1]
         nodes = []
 
-        for rule_index ∈ expand_heuristic(propagate_constraints(grammar, context, grammar[child_type]))
+        for rule_index ∈ expand_heuristic(propagate_constraints(grammar, context, deepcopy(grammar[child_type])))
             # Copy existing children of the current node
             children = deepcopy(node.children)
             # Add the child we are expanding

--- a/src/csg_priority_enumerator.jl
+++ b/src/csg_priority_enumerator.jl
@@ -21,7 +21,7 @@ function Base.iterate(iter::ContextSensitivePriorityEnumerator)
     priority_function, expand_function = iter.priority_function, iter.expand_function
 
     init_node = RuleNode(0)
-    init_context = GrammarContext(init_node)
+    init_context = GrammarContext(init_node, grammar)
 
     rules = [x for x ∈ grammar[sym]]
     rules = propagate_constraints(grammar, init_context, rules)
@@ -48,7 +48,7 @@ Returns nothing if there are no trees left within the depth limit.
 function _find_next_complete_tree(grammar::ContextSensitiveGrammar, max_depth::Int, priority_function::Function, expand_function::Function, pq::PriorityQueue)
     while length(pq) ≠ 0
         (tree, priority_value) = dequeue_pair!(pq)
-        expanded_trees = expand_function(tree, grammar, max_depth - 1, GrammarContext(tree))
+        expanded_trees = expand_function(tree, grammar, max_depth - 1, GrammarContext(tree, grammar))
         if expanded_trees ≡ nothing
             # Current tree is complete, it can be returned
             return (tree, pq)
@@ -88,7 +88,7 @@ function _expand(node::RuleNode, grammar::ContextSensitiveGrammar, max_depth::In
     # This node doesn't have holes, check the children
     if length(childtypes) == length(node.children)
         for (child_index, child) ∈ enumerate(node.children)
-            child_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation))
+            child_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation), grammar)
             push!(child_context.nodeLocation, child_index)
             expanded_child_trees = _expand(child, grammar, max_depth - 1, child_context, expand_heuristic)
             if expanded_child_trees ≡ nothing

--- a/src/csg_priority_enumerator.jl
+++ b/src/csg_priority_enumerator.jl
@@ -21,7 +21,7 @@ function Base.iterate(iter::ContextSensitivePriorityEnumerator)
     priority_function, expand_function = iter.priority_function, iter.expand_function
 
     init_node = RuleNode(0)
-    init_context = GrammarContext(init_node, grammar)
+    init_context = GrammarContext(init_node)
 
     rules = [x for x ∈ grammar[sym]]
     rules = propagate_constraints(grammar, init_context, rules)
@@ -48,7 +48,7 @@ Returns nothing if there are no trees left within the depth limit.
 function _find_next_complete_tree(grammar::ContextSensitiveGrammar, max_depth::Int, priority_function::Function, expand_function::Function, pq::PriorityQueue)
     while length(pq) ≠ 0
         (tree, priority_value) = dequeue_pair!(pq)
-        expanded_trees = expand_function(tree, grammar, max_depth - 1, GrammarContext(tree, grammar))
+        expanded_trees = expand_function(tree, grammar, max_depth - 1, GrammarContext(tree))
         if expanded_trees ≡ nothing
             # Current tree is complete, it can be returned
             return (tree, pq)
@@ -88,7 +88,7 @@ function _expand(node::RuleNode, grammar::ContextSensitiveGrammar, max_depth::In
     # This node doesn't have holes, check the children
     if length(childtypes) == length(node.children)
         for (child_index, child) ∈ enumerate(node.children)
-            child_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation), grammar)
+            child_context = GrammarContext(context.originalExpr, deepcopy(context.nodeLocation))
             push!(child_context.nodeLocation, child_index)
             expanded_child_trees = _expand(child, grammar, max_depth - 1, child_context, expand_heuristic)
             if expanded_child_trees ≡ nothing


### PR DESCRIPTION
Grammars are passed to the propagators.

Also fixes an unrelated bug where eliminating rules from the domain caused the grammar to be modified in L119 of the priority enumerator.

Corresponding PR in Constraints.jl:

- https://github.com/Herb-AI/Constraints.jl/pull/2