### PR TITLE
Overhaul search procedure

### DIFF
--- a/src/HerbSearch.jl
+++ b/src/HerbSearch.jl
@@ -26,6 +26,7 @@ export
   ContextSensitivePriorityEnumerator,
   
   search,
+  search_best,
 
   bfs_expand_heuristic,
   bfs_priority_function,

--- a/src/search_procedure.jl
+++ b/src/search_procedure.jl
@@ -99,7 +99,7 @@ function search_best(
 
     hypotheses = enumerator(g, max_depth ≡ nothing ? typemax(Int) : max_depth , start)
 
-    best_error = typemax(Real)
+    best_error = typemax(Int)
     best_program = nothing
     for (i, h) ∈ enumerate(hypotheses)
         # Create expression from rulenode representation of AST
@@ -111,7 +111,7 @@ function search_best(
             total_error = error_function(total_error, evaluator(symboltable, expr, example.in), example.out)
 
             # Check if we can still improve the best program found so far
-            if sum_of_error ≥ best_error
+            if total_error ≥ best_error
                 break
             end
         end

--- a/src/search_procedure.jl
+++ b/src/search_procedure.jl
@@ -1,27 +1,48 @@
 """
-Searches the grammar up to the provided depth for a program that satisfies problem.
-The evaluator should be a function that takes a SymbolTable, expression and a dictionary with 
-    input variable assignments and returns the output of the expression.
+Searches the grammar for the program that satisfies the maximum number of examples in the problem.
+    
+        - g                 - The grammar that defines the search space
+        - problem           - The problem definition with IO examples
+        - start             - The start symbol in the grammar
+        - evaluator         - The evaluation function. Takes a SymbolTable, expression and a dictionary with 
+                              input variable assignments and returns the output of the expression.
+        - enumerator        - A constructor for the enumerator that should be used in the search
+        - max_depth         - The maximum depth of the search
+        - max_time          - The maximum time allowed for the search in seconds
+        - max_enumerations  - The maximum number of programs to enumerate and test
+    Returns the optimal program once it has been found, or nothing otherwise.
 """
-function search(g::Grammar, problem::Problem, depth::Int, start::Symbol, evaluator=test_with_input, enumerator=get_bfs_enumerator)::Any
+function search(
+        g::Grammar, 
+        problem::Problem, 
+        start::Symbol; 
+        evaluator=test_with_input, 
+        enumerator=get_bfs_enumerator,
+        max_depth::Union{Int, Nothing}=nothing,
+        max_time::Union{Int, Nothing}=nothing,
+        max_enumerations::Union{Int, Nothing}=nothing
+    )::Any
+
+    start_time = time()
+    check_time = max_time !== nothing
+    check_enumerations = max_enumerations !== nothing
     symboltable :: SymbolTable = SymbolTable(g)
 
-    hypotheses = enumerator(g, depth, start)
+    hypotheses = enumerator(g, max_depth ≡ nothing ? typemax(Int) : max_depth , start)
 
-    for h :: RuleNode ∈ hypotheses
+    for (i, h) ∈ enumerate(hypotheses)
         # Create expression from rulenode representation of AST
         expr = rulenode2expr(h, g)
 
-        # Evaluate the examples.
-        satisfied = true
-        for example ∈ filter(e -> e isa IOExample, problem.examples)
-            if example.out ≠ evaluator(symboltable, expr, example.in)
-                satisfied = false
-                break
-            end
-        end
-        if satisfied
+        # Evaluate the examples. 
+        # `all` shortcircuits, so not every example will be evaluated in every iteration. 
+        if all(example.out == evaluator(symboltable, expr, example.in) for example ∈ problem.examples)
             return expr
+        end
+
+        # Check stopping conditions
+        if check_enumerations && i > max_enumerations || check_time && time() - start_time > max_time
+            return nothing
         end
     end
     return nothing
@@ -29,28 +50,58 @@ end
 
 
 """
-Searches the grammar up to the provided depth for the program that satisfies the maximum number of examples in the problem.
+Searches the grammar for the program that satisfies the maximum number of examples in the problem.
 The evaluator should be a function that takes a SymbolTable, expression and a dictionary with 
     input variable assignments and returns the output of the expression.
-Returns a tuple with the found program and a number between 0 and 1 indicating the fraction of examples it satisfies. 
+
+    - g                 - The grammar that defines the search space
+    - problem           - The problem definition with IO examples
+    - start             - The start symbol in the grammar
+    - evaluator         - The evaluation function. Takes a SymbolTable, expression and a dictionary with 
+                          input variable assignments and returns the output of the expression.
+    - enumerator        - A constructor for the enumerator that should be used in the search
+    - max_depth         - The maximum depth of the search
+    - max_time          - The maximum time allowed for the search in seconds
+    - max_enumerations  - The maximum number of programs to enumerate and test
+Returns a tuple with the best found program so far and a number between 0 and 1 indicating the fraction of examples it satisfies. 
+Can be considerably slower than `search` due to having to evaluate each expression on each example.
 """
-function search_best(g::Grammar, problem::Problem, depth::Int, start::Symbol, evaluator=test_with_input, enumerator=get_bfs_enumerator)::Tuple{Any, Real}
+function search_best(
+        g::Grammar, 
+        problem::Problem, 
+        start::Symbol;
+        evaluator=test_with_input, 
+        enumerator=get_bfs_enumerator,
+        max_depth::Union{Int, Nothing}=nothing,
+        max_time::Union{Int, Nothing}=nothing,
+        max_enumerations::Union{Int, Nothing}=nothing
+    )::Tuple{Any, Real}
+
+    start_time = time()
+    check_time = max_time !== nothing
+    check_enumerations = max_enumerations !== nothing
     symboltable :: SymbolTable = SymbolTable(g)
 
-    hypotheses = enumerator(g, depth, start)
+    hypotheses = enumerator(g, max_depth ≡ nothing ? typemax(Int) : max_depth , start)
 
     best_num_passing_examples = -1
     best_program = nothing
-    for h :: RuleNode ∈ hypotheses
+    for (i, h) ∈ enumerate(hypotheses)
         # Create expression from rulenode representation of AST
         expr = rulenode2expr(h, g)
 
+        # Evaluate
         passing_examples = count(evaluator(symboltable, expr, example.in) == example.out for example ∈ problem.examples)
         if passing_examples == length(problem.examples)
-            return expr
+            return expr, 1
         elseif passing_examples > best_num_passing_examples
             best_num_passing_examples = passing_examples
             best_program = expr
+        end
+
+        # Check stopping conditions
+        if check_enumerations && i > max_enumerations || check_time && time() - start_time > max_time
+            return best_program, best_num_passing_examples / length(problem.examples)
         end
     end
     return best_program, best_num_passing_examples / length(problem.examples)

--- a/src/search_procedure.jl
+++ b/src/search_procedure.jl
@@ -90,11 +90,21 @@ function search_best(
         # Create expression from rulenode representation of AST
         expr = rulenode2expr(h, g)
 
-        # Evaluate
-        passing_examples = count(evaluator(symboltable, expr, example.in) == example.out for example ∈ problem.examples)
+        # Evaluate the expression on the examples
+        passing_examples = 0
+        for (j, example) ∈ enumerate(problem.examples)
+            passing_examples += evaluator(symboltable, expr, example.in) == example.out ? 1 : 0
+
+            # Check if we can still improve the best program found so far
+            if passing_examples + length(problem.examples) - j ≤ best_num_passing_examples
+                break
+            end
+        end
+
         if passing_examples == length(problem.examples)
             return expr, 1
         elseif passing_examples > best_num_passing_examples
+            # Update the best found example so far
             best_num_passing_examples = passing_examples
             best_program = expr
         end

--- a/src/search_procedure.jl
+++ b/src/search_procedure.jl
@@ -16,8 +16,8 @@ function search(
         g::Grammar, 
         problem::Problem, 
         start::Symbol; 
-        evaluator=test_with_input, 
-        enumerator=get_bfs_enumerator,
+        evaluator::Function=test_with_input, 
+        enumerator::Function=get_bfs_enumerator,
         max_depth::Union{Int, Nothing}=nothing,
         max_time::Union{Int, Nothing}=nothing,
         max_enumerations::Union{Int, Nothing}=nothing
@@ -50,6 +50,18 @@ end
 
 
 """
+Default error function for `search_best`.
+    
+    - old_error         - The existing total error
+    - output            - The actual output of the evaluator
+    - expected_output   - The expected output for the example
+
+The default function returns `0` if the outputs match and `1` otherwise.
+"""
+default_error_function(old_error, output, expected_output) = old_error + (output == expected_output ? 0 : 1)
+
+
+"""
 Searches the grammar for the program that satisfies the maximum number of examples in the problem.
 The evaluator should be a function that takes a SymbolTable, expression and a dictionary with 
     input variable assignments and returns the output of the expression.
@@ -60,18 +72,21 @@ The evaluator should be a function that takes a SymbolTable, expression and a di
     - evaluator         - The evaluation function. Takes a SymbolTable, expression and a dictionary with 
                           input variable assignments and returns the output of the expression.
     - enumerator        - A constructor for the enumerator that should be used in the search
+    - error_function    - The error function. Takes the existing total error, the actual output of the evaluator 
+                          and the expected value for the example.
     - max_depth         - The maximum depth of the search
     - max_time          - The maximum time allowed for the search in seconds
     - max_enumerations  - The maximum number of programs to enumerate and test
-Returns a tuple with the best found program so far and a number between 0 and 1 indicating the fraction of examples it satisfies. 
+Returns a tuple with the best found program so far and the error. 
 Can be considerably slower than `search` due to having to evaluate each expression on each example.
 """
 function search_best(
         g::Grammar, 
         problem::Problem, 
         start::Symbol;
-        evaluator=test_with_input, 
-        enumerator=get_bfs_enumerator,
+        evaluator::Function=test_with_input, 
+        enumerator::Function=get_bfs_enumerator,
+        error_function::Function=default_error_function,
         max_depth::Union{Int, Nothing}=nothing,
         max_time::Union{Int, Nothing}=nothing,
         max_enumerations::Union{Int, Nothing}=nothing
@@ -84,35 +99,35 @@ function search_best(
 
     hypotheses = enumerator(g, max_depth ≡ nothing ? typemax(Int) : max_depth , start)
 
-    best_num_passing_examples = -1
+    best_error = typemax(Real)
     best_program = nothing
     for (i, h) ∈ enumerate(hypotheses)
         # Create expression from rulenode representation of AST
         expr = rulenode2expr(h, g)
 
         # Evaluate the expression on the examples
-        passing_examples = 0
-        for (j, example) ∈ enumerate(problem.examples)
-            passing_examples += evaluator(symboltable, expr, example.in) == example.out ? 1 : 0
+        total_error = 0
+        for example ∈ problem.examples
+            total_error = error_function(total_error, evaluator(symboltable, expr, example.in), example.out)
 
             # Check if we can still improve the best program found so far
-            if passing_examples + length(problem.examples) - j ≤ best_num_passing_examples
+            if sum_of_error ≥ best_error
                 break
             end
         end
 
-        if passing_examples == length(problem.examples)
-            return expr, 1
-        elseif passing_examples > best_num_passing_examples
+        if total_error == 0
+            return expr, 0
+        elseif total_error < best_error
             # Update the best found example so far
-            best_num_passing_examples = passing_examples
+            best_error = total_error
             best_program = expr
         end
 
         # Check stopping conditions
         if check_enumerations && i > max_enumerations || check_time && time() - start_time > max_time
-            return best_program, best_num_passing_examples / length(problem.examples)
+            return best_program, best_error
         end
     end
-    return best_program, best_num_passing_examples / length(problem.examples)
+    return best_program, best_error
 end

--- a/src/search_procedure.jl
+++ b/src/search_procedure.jl
@@ -1,7 +1,9 @@
 """
-Searches the grammar up to the provided depth for a program that satisfies problem
+Searches the grammar up to the provided depth for a program that satisfies problem.
+The evaluator should be a function that takes a SymbolTable, expression and a dictionary with 
+    input variable assignments and returns the output of the expression.
 """
-function search(g::Grammar, problem::Problem, depth::Int, start::Symbol, enumerator=ExpressionIterator)::Any
+function search(g::Grammar, problem::Problem, depth::Int, start::Symbol, evaluator=test_with_input, enumerator=get_bfs_enumerator)::Any
     symboltable :: SymbolTable = SymbolTable(g)
 
     hypotheses = enumerator(g, depth, start)
@@ -10,9 +12,15 @@ function search(g::Grammar, problem::Problem, depth::Int, start::Symbol, enumera
         # Create expression from rulenode representation of AST
         expr = rulenode2expr(h, g)
 
-        # Evaluate examples the examples.
-        #  `test_examples` returns as soon as it has found the first example that doesn't work.
-        if test_examples(symboltable, expr, problem.examples)
+        # Evaluate the examples.
+        satisfied = true
+        for example ∈ filter(e -> e isa IOExample, problem.examples)
+            if example.out ≠ evaluator(symboltable, expr, example.in)
+                satisfied = false
+                break
+            end
+        end
+        if satisfied
             return expr
         end
     end

--- a/src/search_procedure.jl
+++ b/src/search_procedure.jl
@@ -26,3 +26,32 @@ function search(g::Grammar, problem::Problem, depth::Int, start::Symbol, evaluat
     end
     return nothing
 end
+
+
+"""
+Searches the grammar up to the provided depth for the program that satisfies the maximum number of examples in the problem.
+The evaluator should be a function that takes a SymbolTable, expression and a dictionary with 
+    input variable assignments and returns the output of the expression.
+Returns a tuple with the found program and a number between 0 and 1 indicating the fraction of examples it satisfies. 
+"""
+function search_best(g::Grammar, problem::Problem, depth::Int, start::Symbol, evaluator=test_with_input, enumerator=get_bfs_enumerator)::Tuple{Any, Real}
+    symboltable :: SymbolTable = SymbolTable(g)
+
+    hypotheses = enumerator(g, depth, start)
+
+    best_num_passing_examples = -1
+    best_program = nothing
+    for h :: RuleNode ∈ hypotheses
+        # Create expression from rulenode representation of AST
+        expr = rulenode2expr(h, g)
+
+        passing_examples = count(evaluator(symboltable, expr, example.in) == example.out for example ∈ problem.examples)
+        if passing_examples == length(problem.examples)
+            return expr
+        elseif passing_examples > best_num_passing_examples
+            best_num_passing_examples = passing_examples
+            best_program = expr
+        end
+    end
+    return best_program, best_num_passing_examples / length(problem.examples)
+end

--- a/test/test_search_procedure.jl
+++ b/test/test_search_procedure.jl
@@ -1,24 +1,40 @@
 @testset verbose=true "Search procedure" begin
     g₁ = @cfgrammar begin
-        Number = |(0:4)
+        Number = |(1:5)
         Number = x
         Number = Number + Number
         Number = Number * Number
+        Number = Number - Number
     end
 
     @testset "Search" begin
         problem = Problem([IOExample(Dict(:x => x), 3x+2) for x ∈ 1:5], "")
-        solution = search(g₁, problem, 3, :Number)
+        solution = search(g₁, problem, :Number, max_depth=3)
 
         @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 3*6+2
     end
 
+    @testset "Search max_enumerations stopping condition" begin
+        problem = Problem([IOExample(Dict(:x => x), 3x+2) for x ∈ 1:5], "")
+        solution = search(g₁, problem, :Number, max_enumerations=5)
+
+        @test solution ≡ nothing
+    end
+
     @testset "Best search" begin
         problem = Problem(push!([IOExample(Dict(:x => x), 3x+2) for x ∈ 1:5], IOExample(Dict(:x => 5), 15)), "")
-        solution, correctness = search_best(g₁, problem, 3, :Number)
+        solution, correctness = search_best(g₁, problem, :Number, max_depth=3)
 
         @test correctness ≈ 5/6
         @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 3*6+2
 
+    end
+
+    @testset "Search_best max_enumerations stopping condition" begin
+        problem = Problem([IOExample(Dict(:x => x), 3x-2) for x ∈ 1:5], "")
+        solution, correctness = search_best(g₁, problem, :Number, max_enumerations=5)
+
+        @test solution == 1 || solution == 4
+        @test correctness == 1/5 
     end
 end

--- a/test/test_search_procedure.jl
+++ b/test/test_search_procedure.jl
@@ -1,40 +1,39 @@
 @testset verbose=true "Search procedure" begin
     g₁ = @cfgrammar begin
-        Number = |(1:5)
+        Number = |(1:2)
         Number = x
         Number = Number + Number
         Number = Number * Number
-        Number = Number - Number
     end
 
     @testset "Search" begin
-        problem = Problem([IOExample(Dict(:x => x), 3x+2) for x ∈ 1:5], "")
+        problem = Problem([IOExample(Dict(:x => x), 2x+1) for x ∈ 1:5], "")
         solution = search(g₁, problem, :Number, max_depth=3)
 
-        @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 3*6+2
+        @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 2*6+1
     end
 
     @testset "Search max_enumerations stopping condition" begin
-        problem = Problem([IOExample(Dict(:x => x), 3x+2) for x ∈ 1:5], "")
+        problem = Problem([IOExample(Dict(:x => x), 2x+1) for x ∈ 1:5], "")
         solution = search(g₁, problem, :Number, max_enumerations=5)
 
         @test solution ≡ nothing
     end
 
     @testset "Best search" begin
-        problem = Problem(push!([IOExample(Dict(:x => x), 3x+2) for x ∈ 1:5], IOExample(Dict(:x => 5), 15)), "")
+        problem = Problem(push!([IOExample(Dict(:x => x), 2x+1) for x ∈ 1:5], IOExample(Dict(:x => 5), 15)), "")
         solution, correctness = search_best(g₁, problem, :Number, max_depth=3)
 
         @test correctness ≈ 5/6
-        @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 3*6+2
+        @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 2*6+1
 
     end
 
     @testset "Search_best max_enumerations stopping condition" begin
-        problem = Problem([IOExample(Dict(:x => x), 3x-2) for x ∈ 1:5], "")
-        solution, correctness = search_best(g₁, problem, :Number, max_enumerations=5)
+        problem = Problem([IOExample(Dict(:x => x), 2x-1) for x ∈ 1:5], "")
+        solution, correctness = search_best(g₁, problem, :Number, max_enumerations=2)
 
-        @test solution == 1 || solution == 4
+        @test solution == 1
         @test correctness == 1/5 
     end
 end

--- a/test/test_search_procedure.jl
+++ b/test/test_search_procedure.jl
@@ -1,0 +1,24 @@
+@testset verbose=true "Search procedure" begin
+    g₁ = @cfgrammar begin
+        Number = |(0:4)
+        Number = x
+        Number = Number + Number
+        Number = Number * Number
+    end
+
+    @testset "Search" begin
+        problem = Problem([IOExample(Dict(:x => x), 3x+2) for x ∈ 1:5], "")
+        solution = search(g₁, problem, 3, :Number)
+
+        @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 3*6+2
+    end
+
+    @testset "Best search" begin
+        problem = Problem(push!([IOExample(Dict(:x => x), 3x+2) for x ∈ 1:5], IOExample(Dict(:x => 5), 15)), "")
+        solution, correctness = search_best(g₁, problem, 3, :Number)
+
+        @test correctness ≈ 5/6
+        @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 3*6+2
+
+    end
+end

--- a/test/test_search_procedure.jl
+++ b/test/test_search_procedure.jl
@@ -22,18 +22,18 @@
 
     @testset "Best search" begin
         problem = Problem(push!([IOExample(Dict(:x => x), 2x+1) for x ∈ 1:5], IOExample(Dict(:x => 5), 15)), "")
-        solution, correctness = search_best(g₁, problem, :Number, max_depth=3)
+        solution, error = search_best(g₁, problem, :Number, max_depth=3)
 
-        @test correctness ≈ 5/6
+        @test error == 1
         @test test_with_input(SymbolTable(g₁), solution, Dict(:x => 6)) == 2*6+1
 
     end
 
     @testset "Search_best max_enumerations stopping condition" begin
         problem = Problem([IOExample(Dict(:x => x), 2x-1) for x ∈ 1:5], "")
-        solution, correctness = search_best(g₁, problem, :Number, max_enumerations=2)
+        solution, error = search_best(g₁, problem, :Number, max_enumerations=2)
 
         @test solution == 1
-        @test correctness == 1/5 
+        @test error == 4
     end
 end


### PR DESCRIPTION
Most important changes:

- There is an additional search procedure for returning the best program found if the search terminates before the optimal program has been found. The best program is defined as the program that satisfies the most examples. This is made in a separate search procedure since this does have a noticeable effect on performance. We cannot reject an expression anymore once we have found a single test on which it fails, so we have to do a lot more example evaluations.
- The search procedures now also take an evaluator function, allowing users to provide their own
- The search procedures also take optional stopping procedures:
  - A maximum depth, which was already present but is now provided in a different way
  - A maximum number of seconds
  - A maximum number of programs enumerated
- There are some new tests for the search procedures 

Closes:
- https://github.com/Herb-AI/Herb.jl/issues/33, 
- #3, 
- #17

Include `test_search_procedure.jl` in `herb_test.jl` after merging