### PR TITLE
Add `mod` keyword to search functions

### DIFF
--- a/src/search_procedure.jl
+++ b/src/search_procedure.jl
@@ -1,5 +1,5 @@
 """
-    search_rulenode(g::Grammar, problem::Problem, start::Symbol; evaluator::Function=test_with_input, enumerator::Function=get_bfs_enumerator, max_depth::Union{Int, Nothing}=nothing, max_size::Union{Int, Nothing}=nothing, max_time::Union{Int, Nothing}=nothing, max_enumerations::Union{Int, Nothing}=nothing, allow_evaluation_errors::Bool=false)::Union{Tuple{RuleNode, Any}, Nothing}
+    search_rulenode(g::Grammar, problem::Problem, start::Symbol; evaluator::Function=test_with_input, enumerator::Function=get_bfs_enumerator, max_depth::Union{Int, Nothing}=nothing, max_size::Union{Int, Nothing}=nothing, max_time::Union{Int, Nothing}=nothing, max_enumerations::Union{Int, Nothing}=nothing, allow_evaluation_errors::Bool=false, mod::Module=Main)::Union{Tuple{RuleNode, Any}, Nothing}
 
 Searches the grammar for the program that satisfies the maximum number of examples in the problem.
     
@@ -14,6 +14,7 @@ Searches the grammar for the program that satisfies the maximum number of exampl
         - max_time          - The maximum time allowed for the search in seconds
         - max_enumerations  - The maximum number of programs to enumerate and test'
         - allow_evaluation_errors - Whether the search should crash if an exception is thrown in the evaluation
+        - mod               - A module containing definitions for the functions in the grammar that do not exist in Main
     Returns a tuple of the rulenode and the expression of the solution program once it has been found, 
     or nothing otherwise.
 """
@@ -27,13 +28,14 @@ function search_rulenode(
     max_size::Union{Int, Nothing}=nothing,
     max_time::Union{Int, Nothing}=nothing,
     max_enumerations::Union{Int, Nothing}=nothing,
-    allow_evaluation_errors::Bool=false
+    allow_evaluation_errors::Bool=false,
+    mod::Module=Main,
 )::Union{Tuple{RuleNode, Any}, Nothing}
 
     start_time = time()
     check_time = max_time !== nothing
     check_enumerations = max_enumerations !== nothing
-    symboltable :: SymbolTable = SymbolTable(g)
+    symboltable :: SymbolTable = SymbolTable(g, mod)
 
     hypotheses = enumerator(
         g, 
@@ -80,7 +82,7 @@ end
 
 
 """
-    search(g::Grammar, problem::Problem, start::Symbol; evaluator::Function=test_with_input, enumerator::Function=get_bfs_enumerator, max_depth::Union{Int, Nothing}=nothing, max_size::Union{Int, Nothing}=nothing, max_time::Union{Int, Nothing}=nothing, max_enumerations::Union{Int, Nothing}=nothing, allow_evaluation_errors::Bool=false)::Union{Any, Nothing}
+    search(g::Grammar, problem::Problem, start::Symbol; evaluator::Function=test_with_input, enumerator::Function=get_bfs_enumerator, max_depth::Union{Int, Nothing}=nothing, max_size::Union{Int, Nothing}=nothing, max_time::Union{Int, Nothing}=nothing, max_enumerations::Union{Int, Nothing}=nothing, allow_evaluation_errors::Bool=false, mod::Module=Main)::Union{Any, Nothing}
 
 Searches for a program by calling [`search_rulenode`](@ref) starting from [`Symbol`](@ref) `start` guided by `enumerator` and [`Grammar`](@ref) trying to satisfy  the higher-order constraints in form of input/output examples defined in the [`Problem`](@ref). 
 This is the heart of the Herb's search for satisfying programs.
@@ -96,7 +98,8 @@ function search(
     max_size::Union{Int, Nothing}=nothing,
     max_time::Union{Int, Nothing}=nothing,
     max_enumerations::Union{Int, Nothing}=nothing,
-    allow_evaluation_errors::Bool=false
+    allow_evaluation_errors::Bool=false,
+    mod::Module=Main,
 )::Union{Any, Nothing}
     res::Union{Tuple{RuleNode, Any}, Nothing} = search_rulenode(
         g,
@@ -108,7 +111,8 @@ function search(
         max_size=max_size,
         max_time=max_time,
         max_enumerations=max_enumerations,
-        allow_evaluation_errors=allow_evaluation_errors
+        allow_evaluation_errors=allow_evaluation_errors,
+        mod=mod
     )
 
     if res isa Tuple{RuleNode, Any}
@@ -143,7 +147,7 @@ mse_error_function(old_error, output, expected_output) = old_error + (output - e
 
 
 """
-    search_best(g::Grammar, problem::Problem, start::Symbol; evaluator::Function=test_with_input, enumerator::Function=get_bfs_enumerator, error_function::Function=default_error_function, max_depth::Union{Int, Nothing}=nothing, max_size::Union{Int, Nothing}=nothing, max_time::Union{Int, Nothing}=nothing, max_enumerations::Union{Int, Nothing}=nothing, allow_evaluation_errors::Bool=false)::Tuple{Any, Real}
+    search_best(g::Grammar, problem::Problem, start::Symbol; evaluator::Function=test_with_input, enumerator::Function=get_bfs_enumerator, error_function::Function=default_error_function, max_depth::Union{Int, Nothing}=nothing, max_size::Union{Int, Nothing}=nothing, max_time::Union{Int, Nothing}=nothing, max_enumerations::Union{Int, Nothing}=nothing, allow_evaluation_errors::Bool=false, mod::Module=Main)::Tuple{Any, Real}
 
 Searches the grammar for the program that satisfies the maximum number of examples in the problem.
 The evaluator should be a function that takes a SymbolTable, expression and a dictionary with 
@@ -161,6 +165,7 @@ The evaluator should be a function that takes a SymbolTable, expression and a di
     - max_time          - The maximum time allowed for the search in seconds
     - max_enumerations  - The maximum number of programs to enumerate and test
     - allow_evaluation_errors - Whether the search should crash if an exception is thrown in the evaluation
+    - mod               - A module containing definitions for the functions in the grammar that do not exist in Main
 Returns a tuple with the best found program so far and the error. 
 Can be considerably slower than `search` due to having to evaluate each expression on each example.
 """
@@ -175,13 +180,14 @@ function search_best(
         max_size::Union{Int, Nothing}=nothing,
         max_time::Union{Int, Nothing}=nothing,
         max_enumerations::Union{Int, Nothing}=nothing,
-        allow_evaluation_errors::Bool=false
+        allow_evaluation_errors::Bool=false,
+        mod::Module=Main,
     )::Tuple{Any, Real}
 
     start_time = time()
     check_time = max_time !== nothing
     check_enumerations = max_enumerations !== nothing
-    symboltable :: SymbolTable = SymbolTable(g)
+    symboltable :: SymbolTable = SymbolTable(g, mod)
 
     hypotheses = enumerator(
         g, 


### PR DESCRIPTION
Allows for a user to specify a module from which to load functions that are used in the grammar