### PR TITLE
Print expression when an exception is thrown during evaluation

### DIFF
--- a/src/search_procedure.jl
+++ b/src/search_procedure.jl
@@ -1,3 +1,13 @@
+struct EvaluationError <: Exception
+    expr::Expr
+    input::Dict{Symbol, Any}
+    error::Exception
+end
+
+Base.showerror(io::IO, e::EvaluationError) = print(io, "An exception was thrown while evaluating the expression $(e.expr) on input $(e.input): $(e.error)")
+
+
+
 """
     search_rulenode(g::Grammar, problem::Problem, start::Symbol; evaluator::Function=test_with_input, enumerator::Function=get_bfs_enumerator, max_depth::Union{Int, Nothing}=nothing, max_size::Union{Int, Nothing}=nothing, max_time::Union{Int, Nothing}=nothing, max_enumerations::Union{Int, Nothing}=nothing, allow_evaluation_errors::Bool=false)::Union{Tuple{RuleNode, Any}, Nothing}
 
@@ -61,7 +71,8 @@ function search_rulenode(
                 end
             catch e
                 # Throw the error again if evaluation errors aren't allowed
-                allow_evaluation_errors || throw(e)
+                eval_error = EvaluationError(expr, example.in, e)
+                allow_evaluation_errors || throw(eval_error)
                 falsified = true
                 break
             end
@@ -208,7 +219,8 @@ function search_best(
                 # for example by just increasing the error value and keeping the program as a candidate.
                 crashed = true
                 # Throw the error again if evaluation errors aren't allowed
-                allow_evaluation_errors || throw(e)
+                eval_error = EvaluationError(expr, example.in, e)
+                allow_evaluation_errors || throw(eval_error)
                 break
             end
 


### PR DESCRIPTION
When debugging a grammar that is causing some errors during search, it is helpful to see which exact rule/combination of rules is causing the exception.

With this change, the exception now looks like:

```
An exception was thrown while evaluating the expression SubString(s2, 0, 0)
on input Dict{Symbol, Any}(:s1 => "C0abc", :s2 => "abc"): BoundsError("abc", 0:0)
```

whereas before it only printed the bounds error:

```
BoundsError: attempt to access 3-codeunit String at index [0:0]
```

which doesn't tell you anything about the expression in question.