### PR TITLE
Adding a macro to run iterators for a fixed amount of time

### DIFF
--- a/src/HerbSearch.jl
+++ b/src/HerbSearch.jl
@@ -75,6 +75,6 @@ export
   sample,
   rand
 
-  @timed_exec
+  @timed_exec,
   @timedfor
 end # module HerbSearch

--- a/src/HerbSearch.jl
+++ b/src/HerbSearch.jl
@@ -36,6 +36,8 @@ include("genetic_functions/crossover.jl")
 include("genetic_functions/select_parents.jl")
 include("genetic_search_iterator.jl")
 
+include("utils.jl")
+
 export 
   count_expressions,
   ProgramIterator,
@@ -72,4 +74,7 @@ export
   validate_iterator,
   sample,
   rand
+
+  @timed_exec
+  @timedfor
 end # module HerbSearch

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,79 @@
+"""
+    @timed_exec(seconds, expr::Expr)
+
+Executes `expr` for maximally `seconds` seconds
+
+Example:
+    @timed_exec 2 begin 
+        println("start")
+        sleep(5)
+        println("stop")
+    end
+
+    
+"""
+macro timed_exec(seconds, expr::Expr)
+    return quote
+        tsk = @async $(esc(expr))
+
+        Timer($seconds) do timer
+            istaskdone(tsk) || Base.throwto(tsk, InterruptException())
+        end
+
+        try
+            fetch(tsk)
+        catch _
+            nothing
+        end
+    end
+end
+
+"""
+    @timedfor(var_iter_expr::Expr, body_expr::Expr, seconds::Int64)
+
+Implements an iterator that is allowed to iterator for maximally `seconds` seconds.
+For all practical purposes, this iterator acts as a for loop that checks whether the iteration is taking more time than permitted after processing every element.
+
+Example:
+    @timedfor i in [1,2,3] begin
+        println(i+1)
+        sleep(2)
+    end 3
+"""
+macro timedfor(var_iter_expr::Expr, body_expr::Expr, seconds::Int64)
+    should_end_at = time() + seconds
+    loop_var = var_iter_expr.args[2]
+    loop_iter = var_iter_expr.args[3]
+    quote
+        next = @timed_exec $seconds iterate($loop_iter) 
+
+        while next != nothing
+            # process the element
+            $(esc(loop_var)) =  next[1]
+            $(esc(body_expr))
+
+            if time() > $should_end_at
+                #if we are out of time, stop
+                next = nothing
+            else
+                next = @timed_exec max($should_end_at - time(), 0) iterate($loop_iter, next[2])
+            end
+        end
+    end
+end
+
+
+#@timedfor  i in [1,2,3] begin println(i+1) end 2
+
+
+
+
+# @timed_exec 2 begin
+#     println("first")
+#     sleep(5)
+#     println("second")
+#     end
+
+#@timedfor 2 [1,2,3] println(item)
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,8 @@ Random.seed!(1234)
     include("test_ordered.jl")
     include("test_contains.jl")
 
+    include("test_utils.jl")
+
     # Excluded because it contains long tests
     # include("test_realistic_searches.jl")
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,18 @@
+@testset verbose=true "Utilities" begin
+
+    @testset "Timed iterator" begin
+        rl = []
+        @timedfor i in [1,2,3] begin
+            push!(rl, i)
+        end 2
+        @test length(rl) == 3
+
+        @timedfor i in [1,2,3] begin
+            push!(rl, i)
+            sleep(2)
+        end 3
+        @test length(rl) == 5
+
+    end
+    
+end


### PR DESCRIPTION
Adds two macros:
 - `@timed_exec(seconds, expr::Expr)` for running an expression for a fixed amount seconds
 - `@timedfor(var_iter_expr::Expr, body_expr::Expr, seconds::Int64)` for a timed for loop