### PR TITLE
Make GuidedSearchIterator work with multiple nonterminals

### DIFF
--- a/src/getting_started.jl
+++ b/src/getting_started.jl
@@ -19,7 +19,7 @@ examples = [
             # IOExample(Dict(:arg => "<Change> <string> to <a> number"), "Change string to a number")
         ]
 
-iter = HerbSearch.GuidedSearchIterator(grammar, :S, examples, SymbolTable(grammar))
+iter = HerbSearch.GuidedSearchIterator(grammar, :S, examples, SymbolTable(grammar), :S)
 @profview program = @time probe(examples, iter, 40, 10)
 # program = @time probe(examples, iter,  3600, 10000)
 

--- a/src/getting_started.jl
+++ b/src/getting_started.jl
@@ -19,7 +19,7 @@ examples = [
             # IOExample(Dict(:arg => "<Change> <string> to <a> number"), "Change string to a number")
         ]
 
-iter = HerbSearch.GuidedSearchIterator(grammar, :S, examples, SymbolTable(grammar), :S)
+iter = HerbSearch.GuidedSearchIterator(grammar, :S, examples, SymbolTable(grammar))
 @profview program = @time probe(examples, iter, 40, 10)
 # program = @time probe(examples, iter,  3600, 10000)
 

--- a/src/probe/guided_search_iterator.jl
+++ b/src/probe/guided_search_iterator.jl
@@ -1,8 +1,8 @@
 
 @programiterator GuidedSearchIterator(
     spec::Vector{<:IOExample},
-    symboltable::SymbolTable
-
+    symboltable::SymbolTable,
+    start::Symbol
 )
 Base.@kwdef mutable struct GuidedSearchState
     level::Int64
@@ -44,21 +44,25 @@ function Base.iterate(iter::GuidedSearchIterator, state::GuidedSearchState)::Uni
             # move in advance
             state.next_iter = iterate(state.iter, next_state)
 
-            # evaluate program
-            eval_observation = []
-            expr = rulenode2expr(prog, grammar)
-            for example ∈ iter.spec
-                output = execute_on_input(iter.symboltable, expr, example.in)
-                push!(eval_observation, output)
-            end
+            # evaluate program if starting symbol
+            if return_type(grammar, prog.ind) == iter.start
+                eval_observation = []
+                expr = rulenode2expr(prog, grammar)
+                for example ∈ iter.spec
+                    output = execute_on_input(iter.symboltable, expr, example.in)
+                    push!(eval_observation, output)
+                end
 
-            if eval_observation in state.eval_cache # program already cached
-                continue
+                if eval_observation in state.eval_cache # program already cached
+                    continue
+                end
+                
+                push!(state.eval_cache, eval_observation) # add result to cache
+                push!(state.bank[state.level+1], prog) # add program to bank
+                return (prog, state) # return program
             end
 
             push!(state.bank[state.level+1], prog) # add program to bank
-            push!(state.eval_cache, eval_observation) # add result to cache
-            return (prog, state) # return program
         end
     end
 end

--- a/src/probe/guided_search_iterator.jl
+++ b/src/probe/guided_search_iterator.jl
@@ -2,7 +2,6 @@
 @programiterator GuidedSearchIterator(
     spec::Vector{<:IOExample},
     symboltable::SymbolTable,
-    start::Symbol
 )
 Base.@kwdef mutable struct GuidedSearchState
     level::Int64
@@ -24,6 +23,7 @@ end
 
 function Base.iterate(iter::GuidedSearchIterator, state::GuidedSearchState)::Union{Tuple{RuleNode, GuidedSearchState}, Nothing}
     grammar = get_grammar(iter.solver)
+    start_symbol = get_starting_symbol(iter.solver)
     # wrap in while true to optimize for tail call
     while true
         while state.next_iter === nothing
@@ -45,7 +45,7 @@ function Base.iterate(iter::GuidedSearchIterator, state::GuidedSearchState)::Uni
             state.next_iter = iterate(state.iter, next_state)
 
             # evaluate program if starting symbol
-            if return_type(grammar, prog.ind) == iter.start
+            if return_type(grammar, prog.ind) == start_symbol
                 eval_observation = []
                 expr = rulenode2expr(prog, grammar)
                 for example ∈ iter.spec

--- a/src/probe/new_program_iterator.jl
+++ b/src/probe/new_program_iterator.jl
@@ -55,11 +55,26 @@ function Base.iterate(iter::NewProgramsIterator, state::NewProgramsState)
             else
                 # save current values
                 children, _ = state.cartesian_iter_state
-                rulenode = RuleNode(state.rule_index, collect(children))
+                children = collect(children)
+
                 # move to next cartesian
                 _, next_state = state.cartesian_iter_state
                 state.cartesian_iter_state = iterate(state.cartesian_iter, next_state)
-                return rulenode, state
+
+                # check if selected programs have the correct type
+                types = child_types(iter.grammar, state.rule_index)
+                same_types = true
+                for i in 1:length(types)
+                    if return_type(iter.grammar, children[i]) != types[i]
+                        same_types = false
+                        break
+                    end
+                end
+                
+                if same_types
+                    rulenode = RuleNode(state.rule_index, children)
+                    return rulenode, state
+                end
             end
         end
         state.rule_index += 1

--- a/test/test_newprograms.jl
+++ b/test/test_newprograms.jl
@@ -62,3 +62,28 @@ end
         ]
     end
 end
+@testset "Test new programs iterator" begin
+    @testset "Multiple nonterminals" begin
+        HerbSearch.calculate_rule_cost(rule_index::Int, grammar::ContextSensitiveGrammar) = HerbSearch.calculate_rule_cost_size(rule_index, grammar)
+        grammar = @pcsgrammar begin
+            1 : S = A * B
+            1 : A = "a"
+            1 : B = "b"
+        end
+
+        bank = [[],[],[],[]]
+        for i in 1:3
+            iter = HerbSearch.NewProgramsIterator(i, bank, grammar)
+            for prog in iter
+                push!(bank[i+1], prog)
+            end
+        end
+
+        @test bank == [
+            [],
+            [RuleNode(2), RuleNode(3)],
+            [],
+            [RuleNode(1, [RuleNode(2), RuleNode(3)])]
+        ]
+    end
+end

--- a/test/test_probe.jl
+++ b/test/test_probe.jl
@@ -149,7 +149,7 @@ end
 
         @testset "Running using size-based enumeration" begin
             HerbSearch.calculate_rule_cost(rule_index::Int, grammar::ContextSensitiveGrammar) = HerbSearch.calculate_rule_cost_size(rule_index, grammar)
-            iter = HerbSearch.GuidedSearchIterator(grammar, :S, examples, symboltable, :S)
+            iter = HerbSearch.GuidedSearchIterator(grammar, :S, examples, symboltable)
 
             max_level = 10
             state = nothing
@@ -173,7 +173,7 @@ end
             ]
 
             HerbSearch.calculate_rule_cost(rule_index::Int, grammar::ContextSensitiveGrammar) = HerbSearch.calculate_rule_cost_prob(rule_index, grammar)
-            iter = HerbSearch.GuidedSearchIterator(grammar, :S, examples, symboltable, :S)
+            iter = HerbSearch.GuidedSearchIterator(grammar, :S, examples, symboltable)
 
             max_level = 20
             state = nothing
@@ -202,10 +202,9 @@ end
             ]
 
             HerbSearch.calculate_rule_cost(rule_index::Int, grammar::ContextSensitiveGrammar) = HerbSearch.calculate_rule_cost_size(rule_index, grammar)
-            iter = HerbSearch.GuidedSearchIterator(grammar, :A, examples, SymbolTable(grammar), :A)
+            iter = HerbSearch.GuidedSearchIterator(grammar, :A, examples, SymbolTable(grammar))
 
             progs = []
-
             state = nothing
             next = iterate(iter)
             while next !== nothing
@@ -253,7 +252,7 @@ end
                     HerbSearch.select_partial_solution(partial_sols::Vector{ProgramCache}, all_selected_psols::Set{ProgramCache}) = select_func(partial_sols, all_selected_psols)
 
                     deep_copy_grammar = deepcopy(grammar_to_use)
-                    iter = HerbSearch.GuidedSearchIterator(deep_copy_grammar, :S, examples, symboltable, :S)
+                    iter = HerbSearch.GuidedSearchIterator(deep_copy_grammar, :S, examples, symboltable)
                     max_time = 5
                     runtime = @timed program = probe(examples, iter, max_time, 100)
                     expression = rulenode2expr(program, grammar_to_use)


### PR DESCRIPTION
* `NewProgramsIterator` now checks if the subexpressions have the correct type.
* `GuidedSearchIterator` only returns programs that can be derived from the starting symbol.