### PR TITLE
Make the search start from the best reward position

### DIFF
--- a/src/minecraft/create_minerl_env.jl
+++ b/src/minecraft/create_minerl_env.jl
@@ -2,14 +2,52 @@ using PyCall
 pyimport("minerl")
 
 gym = pyimport("gym")
+# our_seed = 95812 <- hard env
+# our_seed = 958122 
+our_seed = 958129 # initial env
+
+"""
+    resetEnv() 
+This function resets the enviornment with the global provided seed and saves the initial X,Y,Z positions.
+"""
+function resetEnv()
+    env.seed(our_seed)
+    obs = env.reset()
+    global x_player_start, y_player_start, z_player_start = get_xyz_from_env(obs)
+    print(x_player_start, y_player_start, z_player_start)
+    printstyled("Environment created. x: $x_player_start, y: $y_player_start, z: $z_player_start\n", color=:green)
+end
+
+function set_start_xyz(x, y, z)
+    global x_player_start = x
+    global y_player_start = y
+    global z_player_start = z
+    println("New x: $x_player_start y: $y_player_start z: $z_player_start pos")
+end
+function get_xyz_from_env(obs)
+    return obs["xpos"][1], obs["ypos"][1], obs["zpos"][1]
+end
+
+function resetPosition()
+    action = env.action_space.noop()
+    env.set_next_chat_message("/tp @a $(x_player_start) $(y_player_start) $(z_player_start)")
+
+    obs = env.step(action)[1]
+    obsx, obsy, obsz = get_xyz_from_env(obs)
+    while abs(obsx - x_player_start) > 0.1 || abs(obsy - y_player_start) >= 0.1 || abs(obsz - z_player_start) > 0.1
+        obs = env.step(action)[1]
+        obsx, obsy, obsz = get_xyz_from_env(obs)
+        env.render()
+    end
+
+    env.render()
+end
 
 if !@isdefined env
     printstyled("Creating environment\n", color=:yellow)
     env = gym.make("MineRLNavigateDenseProgSynth-v0")
-    env.seed(958129)
-    obs = env.reset()
-    x_player_start, y_player_start, z_player_start = obs["xpos"], obs["ypos"], obs["zpos"]
-    printstyled("Environment created x: $x_player_start, y: $y_player_start, z: $z_player_start\n", color=:green)
+    resetEnv()
+    printstyled("Environment created. x: $x_player_start, y: $y_player_start, z: $z_player_start\n", color=:green)
 else
     printstyled("Environment already created\n", color=:green)
 end

--- a/src/minecraft/create_minerl_env.jl
+++ b/src/minecraft/create_minerl_env.jl
@@ -15,6 +15,24 @@ function resetEnv()
     obs = env.reset()
     global x_player_start, y_player_start, z_player_start = get_xyz_from_env(obs)
     print(x_player_start, y_player_start, z_player_start)
+
+    action = env.action_space.noop()
+    action["forward"] = 1
+
+    # infinite health
+    env.set_next_chat_message("/effect @a minecraft:instant_health 1000000 100 true")
+    env.step(action)
+
+    # infinite food
+    env.set_next_chat_message("/effect @a minecraft:saturation 1000000 255 true")
+    env.step(action)
+
+    # disable mobs
+    env.set_next_chat_message("/gamerule doMobSpawning false")
+    env.step(action)
+    env.set_next_chat_message("/kill @e[type=!player]")
+    env.step(action)
+
     printstyled("Environment created. x: $x_player_start, y: $y_player_start, z: $z_player_start\n", color=:green)
 end
 
@@ -34,13 +52,11 @@ function resetPosition()
 
     obs = env.step(action)[1]
     obsx, obsy, obsz = get_xyz_from_env(obs)
-    while abs(obsx - x_player_start) > 0.1 || abs(obsy - y_player_start) >= 0.1 || abs(obsz - z_player_start) > 0.1
+    while obsx != x_player_start || obsy != y_player_start || obsz != z_player_start
         obs = env.step(action)[1]
         obsx, obsy, obsz = get_xyz_from_env(obs)
-        env.render()
     end
-
-    env.render()
+    println((obsx, obsy, obsz))
 end
 
 if !@isdefined env

--- a/src/minecraft/getting_started_minerl.jl
+++ b/src/minecraft/getting_started_minerl.jl
@@ -60,6 +60,9 @@ function evaluate_trace_minerl(prog, grammar, env, show_moves)
                 break
             end
         end
+        if is_done
+            break
+        end
     end
     println("Reward $sum_of_rewards")
     if sum_of_rewards <= 0.2
@@ -78,7 +81,7 @@ function HerbSearch.set_env_position(x, y, z)
     set_start_xyz(x, y, z)
 end
 #  overwrite the evaluate trace function
-HerbSearch.evaluate_trace(prog::RuleNode, grammar::ContextSensitiveGrammar; show_moves = false) = evaluate_trace_minerl(prog, grammar, env, show_moves)
+HerbSearch.evaluate_trace(prog::RuleNode, grammar::ContextSensitiveGrammar; show_moves=false) = evaluate_trace_minerl(prog, grammar, env, show_moves)
 HerbSearch.calculate_rule_cost(rule_index::Int, grammar::ContextSensitiveGrammar) = HerbSearch.calculate_rule_cost_prob(rule_index, grammar)
 
 # resetEnv()

--- a/src/minecraft/getting_started_minerl.jl
+++ b/src/minecraft/getting_started_minerl.jl
@@ -1,147 +1,88 @@
 include("create_minerl_env.jl")
 using HerbGrammar, HerbSpecification
 using HerbSearch
+using Logging
+disable_logging(LogLevel(1))
 
-os = pyimport("os")
-os.environ["LANG"] = "en_US.UTF-8"
-# you might get an error here. Just type using HerbSearch in the REPL and run the whole file again.
-
-# minerl_grammar = @pcsgrammar begin
-#     10:action_name = "forward" | "left" | "right"
-#     1:action_name =  "jump" 
-#     1:action = Dict("camera" => [0, 0], action_name => 1)
-#     1:sequence_actions = [sequence_actions; action]
-#     1:sequence_actions = []
-# end
+minerl_grammar = @pcsgrammar begin
+    1:action_name = "forward"
+    1:action_name = "left"
+    1:action_name = "right"
+    1:action_name = "back"
+    1:action_name = "jump"
+    1:sequence_actions = [sequence_actions; action]
+    1:sequence_actions = []
+    1:action = (TIMES, Dict("camera" => [0, 0], action_name => 1))
+    5:TIMES = 1 | 5 | 25 | 50 | 75 | 100
+end
 
 minerl_grammar_2 = @pcsgrammar begin
-    100:F = 1
-    1:F = 0
-    1:L = 1
-    100:L = 0
-    1:R = 0
-    100:R = 1
-    100:J = 0
-    1:J = 1
-    100:B = 1
-    1:B = 0
-    10:sequence_actions = [sequence_actions; action]
-    1:sequence_actions = []
-    10:action= (TIMES, Dict("camera" => [0, 0], "forward" => F, "left" => L, "right" => R, "jump" => J, "back" => B))
-    1:TIMES = 25 | 50 | 75 | 100 | 125 | 150 
+    8:DIR = 0b0001 | 0b0010 | 0b0100 | 0b1000 | 0b0101 | 0b1001 | 0b0110 | 0b1010 # forward | back | left | right | forward-left | forward-right | back-left | back-right
+    2:sequence_actions = [sequence_actions; action] | [action]
+    1:action = (25 * TIMES, DIR)
+    6:TIMES = |(1:6)
 end
 
-function create_random_program()
-    return rand(RuleNode, minerl_grammar, :sequence_actions)
-end
-
-iterations = 0
-best_reward = 0
-function evaluate_trace_minerl(prog, grammar, env)
+function evaluate_trace_minerl(prog, grammar, env, show_moves)
     resetPosition()
     expr = rulenode2expr(prog, grammar)
-    # println("expr is: ", expr)
-
-
-    is_done = false
-    is_partial_sol = false
 
     sequence_of_actions = eval(expr)
     if isempty(sequence_of_actions)
-        return (0, 0, 0), false, false, 0
+        return (0, 0, 0), false, 0
     end
 
     sum_of_rewards = 0
+    is_done = false
     obs = nothing
     for saved_action ∈ sequence_of_actions
-        times, action = saved_action
-        
+        times, dir = saved_action
+
         new_action = env.action_space.noop()
-        for key ∈ keys(action)
-            new_action[key] = action[key]
-        end
-        
+        new_action["forward"] = dir & 1
+        new_action["back"] = dir >> 1 & 1
+        new_action["left"] = dir >> 2 & 1
+        new_action["right"] = dir >> 3
+        new_action["jump"] = 1
+        # set player health such that he can never die :)
+        new_action["chat"] = "/effect @a minecraft:instant_health 1 10000 true"
+
         for i in 1:times
             obs, reward, done, _ = env.step(new_action)
-            env.render()
+            if show_moves
+                env.render()
+            end
 
             sum_of_rewards += reward
-
-            if reward > 0
-                is_partial_sol = true
-            end
             if done
-                println("Rewards ", sum_of_rewards)
                 is_done = true
-                printstyled("done\n", color=:green)
+                printstyled("sum of rewards: $sum_of_rewards. Done\n", color=:green)
                 break
             end
         end
     end
-    println("Got reward: ", sum_of_rewards)
-    global best_reward = max(best_reward, sum_of_rewards)
-    printstyled("Best reward: $best_reward\n",color=:red)
-
-    eval_observation = (round(obs["xpos"][1], digits=1), round(obs["ypos"][1], digits=1), round(obs["zpos"][1], digits=1))
-    println(eval_observation)
-    return eval_observation, is_done, is_partial_sol, sum_of_rewards
-end
-
-function run_action(action)
-    obs, reward, done, _ = env.step(action)
-    env.render()
-    println("reward: $reward")
-end
-
-function resetEnv()
-    obs = env.reset()
-    x_player_start, y_player_start, z_player_start = obs["xpos"], obs["ypos"], obs["zpos"]
-    printstyled("Environment reset x: $x_player_start, y: $y_player_start, z: $z_player_start\n", color=:green)
-end
-
-
-function resetPosition()
-    action = env.action_space.noop()
-    action["chat"] = "/tp @a $(x_player_start[1]) $(y_player_start[1]) $(z_player_start[1])"
-    # print("Running chat ", action["chat"])
-
-    env.step(action)
-    env.render()
-end
-
-function run_forward_and_random()
-    while true
-        if rand() < 0.8
-            new_action = env.action_space.noop()
-            new_action["forward"] = 1
-            # new_action["jump"] = 1
-            new_action["spint"] = 1
-            run_action(new_action)
-        else
-            prog = create_random_program()
-            evaluate_trace_minerl(prog, minerl_grammar_2, env)
-        end
+    println("Reward $sum_of_rewards")
+    if sum_of_rewards <= 0.2
+        return (0, 0, 0), false, 0
     end
-
+    obsx, obsy, obsz = get_xyz_from_env(obs)
+    eval_observation = (round(obsx, digits=1), round(obsy, digits=1), round(obsz, digits=1))
+    return eval_observation, is_done, sum_of_rewards
 end
 
-# run_forward_and_random()
+# make sure the probabilities are equal 
+@assert all(prob -> prob == minerl_grammar_2.log_probabilities[begin], minerl_grammar_2.log_probabilities)
 
-# # # overwrite the evaluate trace function
-HerbSearch.evaluate_trace(prog::RuleNode, grammar::ContextSensitiveGrammar) = evaluate_trace_minerl(prog, grammar, env)
+
+function HerbSearch.set_env_position(x, y, z)
+    println("Setting env position")
+    set_start_xyz(x, y, z)
+end
+#  overwrite the evaluate trace function
+HerbSearch.evaluate_trace(prog::RuleNode, grammar::ContextSensitiveGrammar; show_moves = false) = evaluate_trace_minerl(prog, grammar, env, show_moves)
 HerbSearch.calculate_rule_cost(rule_index::Int, grammar::ContextSensitiveGrammar) = HerbSearch.calculate_rule_cost_prob(rule_index, grammar)
+
+# resetEnv()
 iter = HerbSearch.GuidedTraceSearchIterator(minerl_grammar_2, :sequence_actions)
-program = probe(Vector{Trace}(), iter, 400000, 100000)
-
-
-# state = nothing
-# next = iterate(iter)
-# print(next)
-# while next !== nothing
-#     prog, state = next
-#     if (state.level > 100)
-#         break
-#     end
-#     global next = iterate(iter, state)
-# end
+program = probe(Vector{Trace}(), iter, 3000000, 3)
 

--- a/src/minecraft/getting_started_minerl.jl
+++ b/src/minecraft/getting_started_minerl.jl
@@ -28,9 +28,6 @@ function evaluate_trace_minerl(prog, grammar, env, show_moves)
     expr = rulenode2expr(prog, grammar)
 
     sequence_of_actions = eval(expr)
-    if isempty(sequence_of_actions)
-        return (0, 0, 0), false, 0
-    end
 
     sum_of_rewards = 0
     is_done = false
@@ -68,16 +65,14 @@ function evaluate_trace_minerl(prog, grammar, env, show_moves)
     if sum_of_rewards <= 0.2
         return (0, 0, 0), false, 0
     end
-    obsx, obsy, obsz = get_xyz_from_env(obs)
-    eval_observation = (round(obsx, digits=1), round(obsy, digits=1), round(obsz, digits=1))
-    return eval_observation, is_done, sum_of_rewards
+    return get_xyz_from_env(obs), is_done, sum_of_rewards
 end
 
 # make sure the probabilities are equal 
 @assert all(prob -> prob == minerl_grammar_2.log_probabilities[begin], minerl_grammar_2.log_probabilities)
 
 function HerbSearch.set_env_position(x, y, z)
-    println("Setting env position")
+    println("Setting env position: ($x, $y, $z)")
     set_start_xyz(x, y, z)
 end
 #  overwrite the evaluate trace function
@@ -87,4 +82,3 @@ HerbSearch.calculate_rule_cost(rule_index::Int, grammar::ContextSensitiveGrammar
 # resetEnv()
 iter = HerbSearch.GuidedTraceSearchIterator(minerl_grammar_2, :sequence_actions)
 program = probe(Vector{Trace}(), iter, 3000000, 3)
-

--- a/src/minecraft/getting_started_minerl.jl
+++ b/src/minecraft/getting_started_minerl.jl
@@ -18,9 +18,9 @@ end
 
 minerl_grammar_2 = @pcsgrammar begin
     8:DIR = 0b0001 | 0b0010 | 0b0100 | 0b1000 | 0b0101 | 0b1001 | 0b0110 | 0b1010 # forward | back | left | right | forward-left | forward-right | back-left | back-right
-    2:sequence_actions = [sequence_actions; action] | [action]
-    1:action = (25 * TIMES, DIR)
-    6:TIMES = |(1:6)
+    1:sequence_actions = [action]
+    1:action = (TIMES, DIR)
+    6:TIMES = 5 | 10 | 25 | 50 | 75 | 100
 end
 
 function evaluate_trace_minerl(prog, grammar, env, show_moves)
@@ -40,9 +40,8 @@ function evaluate_trace_minerl(prog, grammar, env, show_moves)
         new_action["back"] = dir >> 1 & 1
         new_action["left"] = dir >> 2 & 1
         new_action["right"] = dir >> 3
+        new_action["sprint"] = 1
         new_action["jump"] = 1
-        # set player health such that he can never die :)
-        new_action["chat"] = "/effect @a minecraft:instant_health 1 10000 true"
 
         for i in 1:times
             obs, reward, done, _ = env.step(new_action)
@@ -62,9 +61,6 @@ function evaluate_trace_minerl(prog, grammar, env, show_moves)
         end
     end
     println("Reward $sum_of_rewards")
-    if sum_of_rewards <= 0.2
-        return (0, 0, 0), false, 0
-    end
     return get_xyz_from_env(obs), is_done, sum_of_rewards
 end
 
@@ -81,4 +77,4 @@ HerbSearch.calculate_rule_cost(rule_index::Int, grammar::ContextSensitiveGrammar
 
 # resetEnv()
 iter = HerbSearch.GuidedTraceSearchIterator(minerl_grammar_2, :sequence_actions)
-program = probe(Vector{Trace}(), iter, 3000000, 3)
+program = @time probe(Vector{Trace}(), iter, 3000000, 6)

--- a/src/probe/guided_trace_search_iterator.jl
+++ b/src/probe/guided_trace_search_iterator.jl
@@ -37,12 +37,14 @@ function Base.iterate(iter::GuidedTraceSearchIterator, state::GuidedSearchState)
             # evaluate program if starting symbol
             if return_type(grammar, prog.ind) == start_symbol
                 eval_observation, is_done, final_reward = evaluate_trace(prog, grammar)
-                if eval_observation in state.eval_cache # program already cached
+                eval_observation_rounded = round.(eval_observation, digits=1)
+                if eval_observation_rounded in state.eval_cache # program already cached
                     # print("Skipping this.")
+                    @info "Skipping program"
                     continue
                 end
 
-                push!(state.eval_cache, eval_observation) # add result to cache
+                push!(state.eval_cache, eval_observation_rounded) # add result to cache
                 push!(state.bank[state.level+1], prog) # add program to bank
 
                 return ((prog, (eval_observation, is_done, final_reward)), state) # return program

--- a/src/probe/guided_trace_search_iterator.jl
+++ b/src/probe/guided_trace_search_iterator.jl
@@ -1,12 +1,5 @@
 
 @programiterator GuidedTraceSearchIterator()
-Base.@kwdef mutable struct GuidedSearchState
-    level::Int64
-    bank::Vector{Vector{RuleNode}}
-    eval_cache::Set
-    iter::NewProgramsIterator
-    next_iter::Union{Tuple{RuleNode, NewProgramsState}, Nothing}
-end
 
 function Base.iterate(iter::GuidedTraceSearchIterator)
     iterate(iter, GuidedSearchState(
@@ -43,7 +36,7 @@ function Base.iterate(iter::GuidedTraceSearchIterator, state::GuidedSearchState)
 
             # evaluate program if starting symbol
             if return_type(grammar, prog.ind) == start_symbol
-                eval_observation, is_done, is_partial_sol, final_reward = evaluate_trace(prog, grammar)
+                eval_observation, is_done, final_reward = evaluate_trace(prog, grammar)
                 if eval_observation in state.eval_cache # program already cached
                     # print("Skipping this.")
                     continue

--- a/src/probe/guided_trace_search_iterator.jl
+++ b/src/probe/guided_trace_search_iterator.jl
@@ -11,7 +11,7 @@ function Base.iterate(iter::GuidedTraceSearchIterator)
     ))
 end
 
-function Base.iterate(iter::GuidedTraceSearchIterator, state::GuidedSearchState)::Union{Tuple{RuleNode, GuidedSearchState}, Nothing}
+function Base.iterate(iter::GuidedTraceSearchIterator, state::GuidedSearchState)
     grammar = get_grammar(iter.solver)
     start_symbol = get_starting_symbol(iter.solver)
     # wrap in while true to optimize for tail call
@@ -20,7 +20,7 @@ function Base.iterate(iter::GuidedTraceSearchIterator, state::GuidedSearchState)
             state.level += 1
             push!(state.bank, [])
 
-            state.iter = NewProgramsIterator(state.level, state.bank, grammar) 
+            state.iter = NewProgramsIterator(state.level, state.bank, grammar)
             state.next_iter = iterate(state.iter)
             if state.level > 0
                 @info ("Finished level $(state.level - 1) with $(length(state.bank[state.level])) programs")
@@ -41,10 +41,11 @@ function Base.iterate(iter::GuidedTraceSearchIterator, state::GuidedSearchState)
                     # print("Skipping this.")
                     continue
                 end
-                
+
                 push!(state.eval_cache, eval_observation) # add result to cache
                 push!(state.bank[state.level+1], prog) # add program to bank
-                return (prog, state) # return program
+
+                return ((prog, (eval_observation, is_done, final_reward)), state) # return program
             end
 
             push!(state.bank[state.level+1], prog) # add program to bank

--- a/src/probe/update_grammar.jl
+++ b/src/probe/update_grammar.jl
@@ -43,7 +43,7 @@ function update_grammar!(grammar::ContextSensitiveGrammar, PSols_with_eval_cache
     for rule_index in eachindex(grammar.rules)
         best_reward = 0
         for psol in PSols_with_eval_cache
-            program = psol.program
+            program = psol.program.children[end]
             reward = psol.reward
             # check if the program tree has rule_index somewhere inside it using a recursive function
             if contains_rule(program, rule_index) && reward > best_reward
@@ -52,7 +52,7 @@ function update_grammar!(grammar::ContextSensitiveGrammar, PSols_with_eval_cache
         end
         # fitness higher is better
         # TODO: think about better thing here
-        fitness = best_reward / 64
+        fitness = min(best_reward / 100, 1)
 
         p_current = 2 ^ (grammar.log_probabilities[rule_index])
 
@@ -65,6 +65,8 @@ function update_grammar!(grammar::ContextSensitiveGrammar, PSols_with_eval_cache
         grammar.log_probabilities[rule_index] = grammar.log_probabilities[rule_index] - log(2, sum)
         total_sum += 2^(grammar.log_probabilities[rule_index])
     end
+    expr = rulenode2expr(PSols_with_eval_cache[begin].program, grammar)
+    grammar.rules[9] = :([$expr; action])
     @assert abs(total_sum - 1) <= 1e-4 "Total sum is $(total_sum) "
 end
 

--- a/src/probe/update_grammar.jl
+++ b/src/probe/update_grammar.jl
@@ -54,9 +54,9 @@ function update_grammar!(grammar::ContextSensitiveGrammar, PSols_with_eval_cache
         # TODO: think about better thing here
         fitness = min(best_reward / 100, 1)
 
-        p_current = 2 ^ (grammar.log_probabilities[rule_index])
+        p_current = 2^(grammar.log_probabilities[rule_index])
 
-        sum +=  p_current^(1 - fitness)
+        sum += p_current^(1 - fitness)
         log_prob = ((1 - fitness) * log(2, p_current))
         grammar.log_probabilities[rule_index] = log_prob
     end
@@ -66,7 +66,7 @@ function update_grammar!(grammar::ContextSensitiveGrammar, PSols_with_eval_cache
         total_sum += 2^(grammar.log_probabilities[rule_index])
     end
     expr = rulenode2expr(PSols_with_eval_cache[begin].program, grammar)
-    grammar.rules[9] = :([$expr; action])
+    grammar.rules[1] = :([$expr; ACT])
     @assert abs(total_sum - 1) <= 1e-4 "Total sum is $(total_sum) "
 end
 

--- a/test/test_probe.jl
+++ b/test/test_probe.jl
@@ -191,10 +191,10 @@ end
 
         @testset "Multiple nonterminals" begin
             grammar = @pcsgrammar begin
-                1 : A = 1
-                1 : A = A - B
-                1 : B = 2
-                1 : C = A + B
+                1:A = 1
+                1:A = A - B
+                1:B = 2
+                1:C = A + B
             end
 
             examples = [
@@ -209,7 +209,7 @@ end
             next = iterate(iter)
             while next !== nothing
                 prog, state = next
-                push!(progs, prog)
+                push!(progs, prog[1])
                 if (state.level > 1)
                     break
                 end


### PR DESCRIPTION
Changes I made:
- Add select that selects top 5 best programs in terms of reward
- Add update_grammar for traces that is not used yet. It updates based on reward instead of examples.
- Refactor `x_player_start` variable (and the other y,z) to be a float and not a float array.
- Add `new_action["chat"] = "/effect @a minecraft:instant_health 1 10000 true"` for each action such that the player can't die :)
- Made negative rewards be "_equivalent_" to each other such that they will be not added to the bank.
- When the synthesis restarts, the player will start from the best position found so far. This is a heuristic that seems to work 