### PR TITLE
Remove the Fixed Shaped Iterator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbSearch"
 uuid = "3008d8e8-f9aa-438a-92ed-26e9c7b4829f"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>", "Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -16,7 +16,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 DataStructures = "0.17,0.18"
-HerbConstraints = "0.2.0"
+HerbConstraints = "0.3.0"
 HerbCore = "0.3.0"
 HerbGrammar = "0.5"
 HerbInterpret = "0.1.3"

--- a/src/heuristics.jl
+++ b/src/heuristics.jl
@@ -1,33 +1,5 @@
 using Random
 
-"""
-    heuristic_leftmost_fixed_shaped_hole(node::AbstractRuleNode, max_depth::Int)::Union{ExpandFailureReason, HoleReference}
-    
-Defines a heuristic over [FixedShapeHole](@ref)s, where the left-most hole always gets considered first. Returns a [`HoleReference`](@ref) once a hole is found. This is the default option for enumerators.
-"""
-function heuristic_leftmost_fixed_shaped_hole(node::AbstractRuleNode, max_depth::Int)::Union{ExpandFailureReason, HoleReference}
-    function leftmost(node::AbstractRuleNode, max_depth::Int, path::Vector{Int})::Union{ExpandFailureReason, HoleReference}
-        if max_depth == 0 return limit_reached end
-
-        for (i, child) in enumerate(node.children)
-            new_path = push!(copy(path), i)
-            hole_res = leftmost(child, max_depth-1, new_path)
-            if (hole_res == limit_reached) || (hole_res isa HoleReference)
-                return hole_res
-            end
-        end
-    
-        return already_complete
-    end
-    
-    function leftmost(hole::UniformHole, max_depth::Int, path::Vector{Int})::Union{ExpandFailureReason, HoleReference}
-        if max_depth == 0 return limit_reached end
-        return HoleReference(hole, path)
-    end
-
-    return leftmost(node, max_depth, Vector{Int}())
-end
-
 
 """
     heuristic_leftmost(node::AbstractRuleNode, max_depth::Int)::Union{ExpandFailureReason, HoleReference}

--- a/src/top_down_iterator.jl
+++ b/src/top_down_iterator.jl
@@ -253,20 +253,13 @@ function _find_next_complete_tree(
             hole_res = hole_heuristic(iter, get_tree(solver), get_max_depth(solver))
             if hole_res ≡ already_complete
                 track!(solver, "#FixedShapedTrees")
-                if solver.use_uniformsolver
-                    uniform_solver = UniformSolver(get_grammar(solver), get_tree(solver), with_statistics=solver.statistics)
-                    uniform_iterator = UniformIterator(uniform_solver, iter)
-                    solution = next_solution!(uniform_iterator)
-                    if !isnothing(solution)
-                        enqueue!(pq, uniform_iterator, priority_function(iter, get_grammar(solver), solution, priority_value, true))
-                        return (solution, pq)
-                    end
-                else
-                    fixed_shaped_iter = FixedShapedIterator(get_grammar(solver), :StartingSymbolIsIgnored, solver=solver)
-                    complete_trees = collect(fixed_shaped_iter)
-                    if !isempty(complete_trees)
-                        return (pop!(complete_trees), (complete_trees, pq))
-                    end
+                # Always use the Uniform Solver
+                uniform_solver = UniformSolver(get_grammar(solver), get_tree(solver), with_statistics=solver.statistics)
+                uniform_iterator = UniformIterator(uniform_solver, iter)
+                solution = next_solution!(uniform_iterator)
+                if !isnothing(solution)
+                    enqueue!(pq, uniform_iterator, priority_function(iter, get_grammar(solver), solution, priority_value, true))
+                    return (solution, pq)
                 end
             elseif hole_res ≡ limit_reached
                 # The maximum depth is reached


### PR DESCRIPTION
- [x] removing the use_uniformsolver parameter. And letting use_uniformsolver=true be the default case.
  - [x] remove this parameter from the GenericSolver: https://github.com/Herb-AI/HerbConstraints.jl/pull/70
- [x] deleting fixed_shaped_iterator.jl
- [x] deleting heuristic_leftmost_fixed_shaped_hole

Closes #110 