### PR TITLE
Fix MLFSIterator, add tests for it

### DIFF
--- a/src/top_down_iterator.jl
+++ b/src/top_down_iterator.jl
@@ -39,7 +39,7 @@ end
     function derivation_heuristic(::TopDownIterator, indices::Vector{Int})
 
 Returns a sorted sublist of the `indices`, based on which rules are most promising to fill a hole.
-By default, this is the identity function.
+The underlying solver can change the order within a Hole's domain. We sort the domain to make the enumeration order explicit and more predictable. 
 """
 function derivation_heuristic(::TopDownIterator, indices::Vector{Int})
     return sort(indices);
@@ -153,7 +153,6 @@ function priority_function(
     parent_value::Union{Real, Tuple{Vararg{Real}}},
     isrequeued::Bool
 )
-    #@TODO Add requeueing and calculate values from parent_value
     -max_rulenode_log_probability(current_program, grammar)
 end
 

--- a/test/test_context_free_iterators.jl
+++ b/test/test_context_free_iterators.jl
@@ -1,121 +1,158 @@
 @testset verbose=true "Context-free iterators" begin
-  @testset "length on single Real grammar" begin
-    g1 = @csgrammar begin
-        Real = |(1:9)
+    @testset "length on single Real grammar" begin
+        g1 = @csgrammar begin
+            Real = |(1:9)
+        end
+
+        @test length(BFSIterator(g1, :Real, max_depth=1)) == 9
+        @test length(DFSIterator(g1, :Real, max_depth=1)) == 9
+
+        # Tree depth is equal to 1, so the max depth of 3 does not change the expression count
+        @test length(BFSIterator(g1, :Real, max_depth=3)) == 9
+        @test length(DFSIterator(g1, :Real, max_depth=3)) == 9
     end
 
-    @test length(BFSIterator(g1, :Real, max_depth=1)) == 9
+    @testset "length on grammar with multiplication" begin
+        g1 = @csgrammar begin
+            Real = 1 | 2
+            Real = Real * Real 
+        end
+        # Expressions: [1, 2]  
+        @test length(BFSIterator(g1, :Real, max_depth=1)) == 2
+        @test length(DFSIterator(g1, :Real, max_depth=1)) == 2
 
-    # Tree depth is equal to 1, so the max depth of 3 does not change the expression count
-    @test length(BFSIterator(g1, :Real, max_depth=3)) == 9
-  end
-
-  @testset "length on grammar with multiplication" begin
-    g1 = @csgrammar begin
-        Real = 1 | 2
-        Real = Real * Real 
-    end
-    # Expressions: [1, 2]  
-    @test length(BFSIterator(g1, :Real, max_depth=1)) == 2
-
-    # Expressions: [1, 2, 1 * 1, 1 * 2, 2 * 1, 2 * 2] 
-    @test length(BFSIterator(g1, :Real, max_depth=2)) == 6
-  end
-
-  @testset "length on different arithmetic operators" begin
-    g1 = @csgrammar begin
-        Real = 1
-        Real = Real * Real 
+        # Expressions: [1, 2, 1 * 1, 1 * 2, 2 * 1, 2 * 2] 
+        @test length(BFSIterator(g1, :Real, max_depth=2)) == 6
+        @test length(DFSIterator(g1, :Real, max_depth=2)) == 6
     end
 
-    g2 = @csgrammar begin
-      Real = 1
-      Real = Real / Real 
+    @testset "length on different arithmetic operators" begin
+        g1 = @csgrammar begin
+            Real = 1
+            Real = Real * Real 
+        end
+
+        g2 = @csgrammar begin
+            Real = 1
+            Real = Real / Real 
+        end
+
+        g3 = @csgrammar begin
+            Real = 1
+            Real = Real + Real 
+        end 
+
+        g4 = @csgrammar begin
+            Real = 1
+            Real = Real - Real 
+        end 
+        
+        g5 = @csgrammar begin
+            Real = 1
+            Real = Real % Real 
+        end 
+
+        g6 = @csgrammar begin
+            Real = 1
+            Real = Real \ Real 
+        end 
+
+        g7 = @csgrammar begin
+            Real = 1
+            Real = Real ^ Real 
+        end 
+
+        g8 = @csgrammar begin
+            Real = 1
+            Real = -Real * Real 
+        end
+        
+        # E.q for multiplication: [1, 1 * 1, 1 * (1 * 1), (1 * 1) * 1, (1 * 1) * (1 * 1)] 
+        @test length(BFSIterator(g1, :Real, max_depth=3)) == 5
+        @test length(BFSIterator(g2, :Real, max_depth=3)) == 5
+        @test length(BFSIterator(g3, :Real, max_depth=3)) == 5
+        @test length(BFSIterator(g4, :Real, max_depth=3)) == 5
+        @test length(BFSIterator(g5, :Real, max_depth=3)) == 5
+        @test length(BFSIterator(g6, :Real, max_depth=3)) == 5
+        @test length(BFSIterator(g7, :Real, max_depth=3)) == 5
+        @test length(BFSIterator(g8, :Real, max_depth=3)) == 5
+
+        @test length(DFSIterator(g1, :Real, max_depth=3)) == 5
+        @test length(DFSIterator(g2, :Real, max_depth=3)) == 5
+        @test length(DFSIterator(g3, :Real, max_depth=3)) == 5
+        @test length(DFSIterator(g4, :Real, max_depth=3)) == 5
+        @test length(DFSIterator(g5, :Real, max_depth=3)) == 5
+        @test length(DFSIterator(g6, :Real, max_depth=3)) == 5
+        @test length(DFSIterator(g7, :Real, max_depth=3)) == 5
+        @test length(DFSIterator(g8, :Real, max_depth=3)) == 5
+
     end
 
-    g3 = @csgrammar begin
-      Real = 1
-      Real = Real + Real 
-    end 
+    @testset "length on grammar with functions" begin
+        g1 = @csgrammar begin
+            Real = 1 | 2
+            Real = f(Real)                # function call
+        end
 
-    g4 = @csgrammar begin
-      Real = 1
-      Real = Real - Real 
-    end 
-    
-    g5 = @csgrammar begin
-      Real = 1
-      Real = Real % Real 
-    end 
+        # Expressions: [1, 2, f(1), f(2)]
+        @test length(BFSIterator(g1, :Real, max_depth=2)) == 4
+        @test length(DFSIterator(g1, :Real, max_depth=2)) == 4
 
-    g6 = @csgrammar begin
-      Real = 1
-      Real = Real \ Real 
-    end 
-
-    g7 = @csgrammar begin
-      Real = 1
-      Real = Real ^ Real 
-    end 
-
-    g8 = @csgrammar begin
-      Real = 1
-      Real = -Real * Real 
-    end
-    
-    # E.q for multiplication: [1, 1 * 1, 1 * (1 * 1), (1 * 1) * 1, (1 * 1) * (1 * 1)] 
-    @test length(BFSIterator(g1, :Real, max_depth=3)) == 5
-    @test length(BFSIterator(g2, :Real, max_depth=3)) == 5
-    @test length(BFSIterator(g3, :Real, max_depth=3)) == 5
-    @test length(BFSIterator(g4, :Real, max_depth=3)) == 5
-    @test length(BFSIterator(g5, :Real, max_depth=3)) == 5
-    @test length(BFSIterator(g6, :Real, max_depth=3)) == 5
-    @test length(BFSIterator(g7, :Real, max_depth=3)) == 5
-    @test length(BFSIterator(g8, :Real, max_depth=3)) == 5
-  end
-
-  @testset "length on grammar with functions" begin
-    g1 = @csgrammar begin
-        Real = 1 | 2
-        Real = f(Real)                # function call
+        # Expressions: [1, 2, f(1), f(2), f(f(1)), f(f(2))]
+        @test length(BFSIterator(g1, :Real, max_depth=3)) == 6
+        @test length(DFSIterator(g1, :Real, max_depth=3)) == 6
     end
 
-    # Expressions: [1, 2, f(1), f(2)]
-    @test length(BFSIterator(g1, :Real, max_depth=2)) == 4
-
-    # Expressions: [1, 2, f(1), f(2), f(f(1)), f(f(2))]
-    @test length(BFSIterator(g1, :Real, max_depth=3)) == 6
-  end
-
-  @testset "bfs enumerator" begin
-    g1 = @csgrammar begin
-      Real = 1 | 2
-      Real = Real * Real
-    end
-    programs = [freeze_state(p) for p ∈ BFSIterator(g1, :Real, max_depth=2)]
-    @test all(map(t -> depth(t[1]) ≤ depth(t[2]), zip(programs[begin:end-1], programs[begin+1:end])))
-    
     answer_programs = [
-      RuleNode(1),
-      RuleNode(2),
-      RuleNode(3, [RuleNode(1), RuleNode(1)]),
-      RuleNode(3, [RuleNode(1), RuleNode(2)]),
-      RuleNode(3, [RuleNode(2), RuleNode(1)]),
-      RuleNode(3, [RuleNode(2), RuleNode(2)])
-    ]
+        RuleNode(1),
+        RuleNode(2),
+        RuleNode(3, [RuleNode(1), RuleNode(1)]),
+        RuleNode(3, [RuleNode(1), RuleNode(2)]),
+        RuleNode(3, [RuleNode(2), RuleNode(1)]),
+        RuleNode(3, [RuleNode(2), RuleNode(2)])
+        ]
 
-    @test length(programs) == 6
+    @testset "BFSIterator test" begin
+        g1 = @csgrammar begin
+            Real = 1 | 2
+            Real = Real * Real
+        end
+        bfs_programs = [freeze_state(p) for p ∈ BFSIterator(g1, :Real, max_depth=2)]
+        # Test for increasing program depth
+        @test all(map(t -> depth(t[1]) ≤ depth(t[2]), zip(bfs_programs[begin:end-1], bfs_programs[begin+1:end])))
 
-    @test all(p ∈ programs for p ∈ answer_programs)
-  end
-
-  @testset "dfs enumerator" begin
-    g1 = @csgrammar begin
-      Real = 1 | 2
-      Real = Real * Real
+        @test length(bfs_programs) == 6
+        @test all(p ∈ bfs_programs for p ∈ answer_programs)
     end
 
-    @test length(BFSIterator(g1, :Real, max_depth=2)) == 6
-  end
+    @testset "DFSIterator test" begin
+        g1 = @csgrammar begin
+            Real = 1 | 2
+            Real = Real * Real
+        end
+    
+        dfs_programs = [freeze_state(p) for p ∈ DFSIterator(g1, :Real, max_depth=2)]
+        
+        @test length(dfs_programs) == 6
+        @test all(p ∈ dfs_programs for p ∈ answer_programs)
+    end
 
+    @testset verbose=true "MLFSIterator tests" begin
+        g = @pcsgrammar begin
+            0.2 : Real = 1
+            0.3 : Real = 2
+            0.5 : Real = Real * Real
+        end
+
+        log_p(p) = rulenode_log_probability(p, g)
+
+        iter = MLFSIterator(g, :Real, max_depth=2)
+
+        mlfs_programs = [freeze_state(p) for p ∈ iter]
+
+        # Test for drecreasing program probability
+        @test all(map(t -> log_p(t[1]) >= log_p(t[2]), zip(mlfs_programs[begin:end-1], mlfs_programs[begin+1:end])))
+        @test length(mlfs_programs) == 6
+        @test all(p ∈ mlfs_programs for p ∈ answer_programs)
+    end
 end

--- a/test/test_search_procedure.jl
+++ b/test/test_search_procedure.jl
@@ -74,7 +74,7 @@
         iterator = BFSIterator(g₃, :Index, max_depth=2)
         solution, flag = synth(problem, iterator, allow_evaluation_errors=true) 
 
-        @test solution == RuleNode(3, [RuleNode(2), RuleNode(1)])
+        @test solution == @rulenode 3{2,1}
         @test flag == suboptimal_program
     end
 end


### PR DESCRIPTION
Also:
- fixed enumeration order for DFS
- I added tests for DFS because there were none previously.

`MLFSIterator` requires https://github.com/Herb-AI/HerbGrammar.jl/pull/104 to work.