### PR TITLE
Fix extension formulation of divide_and_conquer; fix decide

### DIFF
--- a/ext/DivideAndConquerExt/DivideAndConquerExt.jl
+++ b/ext/DivideAndConquerExt/DivideAndConquerExt.jl
@@ -13,8 +13,6 @@ include("divide.jl")
 include("decide.jl")
 include("conquer.jl")
 
-export divide_and_conquer
-
 """
 		$(TYPEDSIGNATURES)
 Synthesizes a program using a divide and conquer strategy. 
@@ -35,7 +33,7 @@ Breaks down the problem into smaller subproblems and synthesizes solutions for e
 
 Returns the `RuleNode` representing the final program constructed from the solutions to the subproblems.
 """
-function divide_and_conquer(problem::Problem,
+function HerbSearch.divide_and_conquer(problem::Problem,
 	iterator::ProgramIterator,
 	sym_bool::Symbol,
 	sym_start::Symbol,

--- a/ext/DivideAndConquerExt/decide.jl
+++ b/ext/DivideAndConquerExt/decide.jl
@@ -14,7 +14,7 @@ function decide(
 	expr::Any,
 	symboltable::SymbolTable,
 )::Bool
-	score = HerbSearch.evaluate(problem, expr, symboltable, allow_evaluation_errors = false)
+	score = HerbSearch.evaluate(problem, expr, symboltable, allow_evaluation_errors = true)
 	return score == 1
 end
 


### PR DESCRIPTION
Two fixes:
- Extension was just declaring a new function `divide_and_conquer`, but was not ~overwriting~ extending the `HerbSearch` function
- `decide` should allow for evaluation errors, and not error the meta-procedure.