### PR TITLE
Run doctests as part of testing

### DIFF
--- a/src/program_iterator.jl
+++ b/src/program_iterator.jl
@@ -45,8 +45,6 @@ root of each of the programs returned from the iterator will have the same
 type, and this will match the symbol returned by [`get_starting_symbol`](@ref).
 
 ```jldoctest
-julia> using HerbGrammar, HerbConstraints;
-
 julia> g = @csgrammar begin
            Int = length(List)
            Int = Int + Int
@@ -55,19 +53,20 @@ julia> g = @csgrammar begin
 
 julia> it = BFSIterator(g, :Int; max_depth=4);
 
-julia> root_rules = get_rule.(it);
-
-julia> [g.types[idx] for idx in root_rules]
-5-element Vector{Symbol}:
- :Int
- :Int
- :Int
- :Int
- :Int
+julia> programs = rulenode2expr.((freeze_state(p) for p in it), (g,))
+5-element Vector{Expr}:
+ :(length(x))
+ :(length(x) + length(x))
+ :(length(x) + (length(x) + length(x)))
+ :((length(x) + length(x)) + length(x))
+ :((length(x) + length(x)) + (length(x) + length(x)))
 
 julia> get_starting_symbol(it)
 :Int
 ```
+
+Note that all of the programs will return an `Int`, matching the type returned
+by `get_starting_symbol(it)`.
 """
 function HerbConstraints.get_starting_symbol(pi::ProgramIterator)
     return get_starting_symbol(get_solver(pi))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 HerbConstraints = "1fa96474-3206-4513-b4fa-23913f296dfc"
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,35 +7,39 @@ using HerbConstraints
 using HerbSpecification
 using Test
 using Aqua
+using Documenter
+
+DocMeta.setdocmeta!(HerbSearch, :DocTestSetup, :(using HerbCore,
+        HerbConstraints, HerbGrammar, HerbSearch); recursive=true)
 
 include("test_helpers.jl")
 using Random
 Random.seed!(1234)
 
 @testset "HerbSearch.jl" verbose = true begin
-	@testset "Aqua" Aqua.test_all(
-		HerbSearch,
-		piracies = (treat_as_own = [RuleNode, AbstractGrammar],),
-	)
-	include("test_search_procedure.jl")
-	include("test_context_free_iterators.jl")
-	include("test_sampling.jl")
-	include("test_stochastic/test_stochastic.jl")
-	include("test_genetic.jl")
-	include("test_programiterator_macro.jl")
-	include("test_uniform_iterator.jl")
-	include("test_forbidden.jl")
-	include("test_ordered.jl")
-	include("test_contains.jl")
-	include("test_contains_subtree.jl")
-	include("test_unique.jl")
-	include("test_constraints.jl")
+    @testset "Aqua" Aqua.test_all(
+        HerbSearch,
+        piracies=(treat_as_own=[RuleNode, AbstractGrammar],),
+    )
+    include("test_search_procedure.jl")
+    include("test_context_free_iterators.jl")
+    include("test_sampling.jl")
+    include("test_stochastic/test_stochastic.jl")
+    include("test_genetic.jl")
+    include("test_programiterator_macro.jl")
+    include("test_uniform_iterator.jl")
+    include("test_forbidden.jl")
+    include("test_ordered.jl")
+    include("test_contains.jl")
+    include("test_contains_subtree.jl")
+    include("test_unique.jl")
+    include("test_constraints.jl")
 
-	# 	# Excluded because it contains long tests
-	# 	# include("test_realistic_searches.jl")
-end
-
-@testset verbose = true "Divide and conquer extension" begin
-	include("test_divide_conquer.jl")
-	include("test_divide_conquer_example.jl")
+    # Excluded because it contains long tests
+    # include("test_realistic_searches.jl")
+    @testset verbose = true "Divide and conquer extension" begin
+        include("test_divide_conquer.jl")
+        include("test_divide_conquer_example.jl")
+    end
+    doctest(HerbSearch; manual=false)
 end


### PR DESCRIPTION
Previously, we did not run the doctests that we've included. This change adds them to `runtests.jl`.