### PR TITLE
Fix `current_index` logic in `fill_hole!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HerbSearch"
 uuid = "3008d8e8-f9aa-438a-92ed-26e9c7b4829f"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>", "Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>"]
 
 [deps]

--- a/test/test_asp_iterator.jl
+++ b/test/test_asp_iterator.jl
@@ -36,4 +36,13 @@
         @test length(dfs_programs) == 6
         @test all(p ∈ dfs_programs for p ∈ answer_programs)
     end
+
+    @testset "Issue 175: Invalid mapping" begin
+        g = @csgrammar begin
+            Int = Int + Int
+            Int = 1 | 2
+        end
+        iter = BFSASPIterator(g, :Int, max_depth=3)
+        @test length(collect(iter)) > 0
+    end
 end


### PR DESCRIPTION
The logic for calculating the `current_index` when filling in ASP solutions was incorrect (see #175).

This PR corrects the index calculations.