### PR TITLE
fix: `HerbConstraints` compat bound to `1.1`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HerbSearch"
 uuid = "3008d8e8-f9aa-438a-92ed-26e9c7b4829f"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>", "Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>"]
 
 [deps]
@@ -26,7 +26,7 @@ DivideAndConquerExt = "DecisionTree"
 DataStructures = "0.19"
 DecisionTree = "0.12"
 DocStringExtensions = "0.9"
-HerbConstraints = "1"
+HerbConstraints = "1.1"
 HerbCore = "1"
 HerbGrammar = "1"
 HerbInterpret = "1"


### PR DESCRIPTION
Currently, the compat bound for `HerbConstraints` is too loose, allowing one to install constraints `@1.0` alongside search `@1.0`, which is actually incompatible. This PR bumps the compat bound to `1.1`.

<details><summary>Precompilation error</summary>
<p>

```julia
Failed to precompile HerbSearch [3008d8e8-f9aa-438a-92ed-26e9c7b4829f] to "~/.julia/compiled/v1.12/HerbSearch/jl_S2VaXk".
ERROR: LoadError: UndefVarError: `ASPSolver` not defined in `HerbSearch`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
  [1] top-level scope
    @ ~/.julia/dev/HerbSearch/src/uniform_asp_iterator.jl:7
  [2] include(mapexpr::Function, mod::Module, _path::String)
    @ Base ./Base.jl:307
  [3] top-level scope
    @ ~/.julia/dev/HerbSearch/src/HerbSearch.jl:19
  [4] include(mod::Module, _path::String)
    @ Base ./Base.jl:306
  [5] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
    @ Base ./loading.jl:3024
  [6] top-level scope
    @ stdin:5
  [7] eval(m::Module, e::Any)
    @ Core ./boot.jl:489
  [8] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)
    @ Base ./loading.jl:2870
  [9] include_string
    @ ./loading.jl:2880 [inlined]
 [10] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:315
 [11] _start()
    @ Base ./client.jl:550
```

</p>
</details> 